### PR TITLE
Créer un projet Python Replit déployable sur Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,133 @@ temp/
 
 # Local Netlify folder
 .netlify
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/.replit
+++ b/.replit
@@ -1,0 +1,24 @@
+language = "python3"
+run = "python main.py"
+entrypoint = "main.py"
+
+[nix]
+channel = "stable-22_11"
+
+[env]
+PYTHONPATH = "${PYTHONPATH}:${REPL_HOME}"
+
+[packager]
+language = "python3"
+ignoredPackages = ["unit_tests"]
+
+[packager.features]
+packageSearch = true
+guessImports = true
+
+[languages.python3]
+pattern = "**/*.py"
+syntax = "python"
+
+[languages.python3.languageServer]
+start = [ "python", "-m", "pylsp" ]

--- a/README.md
+++ b/README.md
@@ -1,179 +1,168 @@
-# 🌿 CBD Premium Boutique
+# API Python pour Replit et Vercel
 
-Une boutique en ligne moderne et responsive pour les produits CBD, construite avec Next.js 14, Tailwind CSS et optimisée pour le déploiement sur Vercel.
+Ce projet est une API Python simple qui peut être développée sur Replit et déployée sur Vercel.
 
-## ✨ Fonctionnalités
+## 🚀 Fonctionnalités
 
-### 🛍️ Boutique
-- **Page d'accueil** : Affichage des produits sous forme de cartes avec vidéos
-- **Pages de détail** : Vidéos intégrées, descriptions complètes, boutons de commande
-- **Design responsive** : Optimisé pour mobile, tablette et desktop
-- **Mode sombre/clair** : Basculement automatique selon la configuration
+- API REST avec Flask
+- Endpoints pour différents services
+- Compatible avec Replit et Vercel
+- Configuration automatique pour le déploiement
 
-### 🔐 Administration
-- **Authentification simple** : Connexion par mot de passe
-- **Gestion des produits** : Ajout, modification, suppression
-- **Configuration de la boutique** : Nom, description, couleurs, mode sombre
-- **Gestion des médias** : Upload d'images et vidéos via URLs
-- **Liens sociaux** : Configuration des réseaux sociaux
+## 📋 Endpoints disponibles
 
-### 🎨 Personnalisation
-- **Thème personnalisable** : Couleurs, images de fond
-- **Mode sombre/clair** : Basculement automatique
-- **Footer configurable** : Texte et liens personnalisables
-- **SEO optimisé** : Métadonnées configurables
+### GET /
+Page d'accueil avec informations de base
 
-## 🚀 Technologies
+### GET /api/hello?name=Nom
+Salutation personnalisée
 
-- **Next.js 14** : Framework React avec App Router
-- **TypeScript** : Typage statique pour la sécurité
-- **Tailwind CSS** : Framework CSS utilitaire
-- **Lucide React** : Icônes modernes
-- **JSON Storage** : Stockage des données en fichiers JSON
+### GET /api/weather
+Informations météo simulées
 
-## 📦 Installation
+### GET /api/users
+Liste des utilisateurs
 
-1. **Cloner le projet**
+### POST /api/users
+Créer un nouvel utilisateur
+
+## 🛠️ Installation et développement
+
+### Sur Replit
+
+1. Clonez ce repository dans votre Replit
+2. Les dépendances s'installeront automatiquement
+3. Cliquez sur "Run" pour démarrer le serveur
+
+### En local
+
 ```bash
-git clone <repository-url>
-cd cbd-boutique
+# Installer les dépendances
+pip install -r requirements.txt
+
+# Démarrer le serveur
+python main.py
 ```
 
-2. **Installer les dépendances**
-```bash
-npm install
-```
+Le serveur sera accessible sur `http://localhost:8080`
 
-3. **Lancer en développement**
-```bash
-npm run dev
-```
+## 🚀 Déploiement sur Vercel
 
-4. **Ouvrir dans le navigateur**
+### Prérequis
+
+1. Compte Vercel
+2. CLI Vercel installé (`npm i -g vercel`)
+
+### Étapes de déploiement
+
+1. **Connectez-vous à Vercel :**
+   ```bash
+   vercel login
+   ```
+
+2. **Déployez le projet :**
+   ```bash
+   vercel
+   ```
+
+3. **Pour les déploiements suivants :**
+   ```bash
+   vercel --prod
+   ```
+
+### Configuration Vercel
+
+Le fichier `vercel.json` configure automatiquement :
+- Le runtime Python 3.9
+- Les routes vers l'API
+- La structure de déploiement
+
+## 📁 Structure du projet
+
 ```
-http://localhost:3000
+├── api/
+│   └── index.py          # Point d'entrée pour Vercel
+├── main.py               # Point d'entrée pour Replit/local
+├── requirements.txt       # Dépendances Python
+├── vercel.json           # Configuration Vercel
+├── .replit               # Configuration Replit
+├── pyproject.toml        # Configuration Python moderne
+└── README.md             # Ce fichier
 ```
 
 ## 🔧 Configuration
 
-### Configuration initiale
-Le mot de passe admin par défaut est `admin123`. Vous pouvez le modifier dans `src/data/config.json`.
+### Variables d'environnement
 
-### Structure des données
-- `src/data/products.json` : Liste des produits
-- `src/data/config.json` : Configuration de la boutique
+Créez un fichier `.env` pour les variables locales :
 
-### Ajout de produits
-1. Accédez à `/admin`
-2. Connectez-vous avec le mot de passe
-3. Cliquez sur "Ajouter un produit"
-4. Remplissez les informations :
-   - Nom du produit
-   - Description
-   - Prix
-   - URL de l'image
-   - URL de la vidéo
-   - Lien de commande
-   - Slug (URL unique)
+```env
+FLASK_ENV=development
+PORT=8080
+```
 
-## 🎯 Déploiement sur Vercel
+### Personnalisation
 
-### 1. Préparation
+1. **Ajouter de nouveaux endpoints :** Modifiez `api/index.py`
+2. **Changer la configuration :** Modifiez `vercel.json`
+3. **Ajouter des dépendances :** Modifiez `requirements.txt`
+
+## 🧪 Tests
+
 ```bash
-# Build du projet
-npm run build
+# Installer les dépendances de développement
+pip install -e ".[dev]"
 
-# Test en production
-npm start
+# Lancer les tests
+pytest
+
+# Formater le code
+black .
+
+# Vérifier la qualité du code
+flake8 .
 ```
 
-### 2. Déploiement automatique
-1. Connectez votre repository GitHub à Vercel
-2. Vercel détectera automatiquement Next.js
-3. Le déploiement se fera automatiquement à chaque push
+## 📝 Exemples d'utilisation
 
-### 3. Variables d'environnement (optionnel)
-Si nécessaire, ajoutez des variables d'environnement dans Vercel :
-- `NEXT_PUBLIC_SITE_URL` : URL de votre site
-- `ADMIN_PASSWORD` : Mot de passe admin (remplace le fichier config)
+### Test de l'API
 
-## 📱 Responsive Design
-
-Le site est optimisé pour :
-- **Mobile** : < 768px
-- **Tablette** : 768px - 1024px
-- **Desktop** : > 1024px
-
-## 🎨 Personnalisation
-
-### Couleurs
-Modifiez les couleurs dans `tailwind.config.js` ou utilisez les classes Tailwind directement.
-
-### Images et vidéos
-- Utilisez des URLs externes pour les médias
-- Formats supportés : JPG, PNG, MP4, WebM
-- Taille recommandée : 1920x1080 pour les vidéos
-
-### Police
-La police Geist est utilisée par défaut. Vous pouvez la changer dans `src/app/layout.tsx`.
-
-## 🔒 Sécurité
-
-- Authentification simple par mot de passe
-- Validation des données côté serveur
-- Protection contre les injections
-- Headers de sécurité automatiques
-
-## 📈 Performance
-
-- **Images optimisées** : Next.js Image component
-- **Lazy loading** : Chargement différé des médias
-- **Code splitting** : Chargement à la demande
-- **SEO optimisé** : Métadonnées dynamiques
-
-## 🛠️ Développement
-
-### Structure du projet
-```
-src/
-├── app/                 # Pages Next.js 14
-│   ├── admin/          # Panel d'administration
-│   ├── api/            # API routes
-│   ├── produit/        # Pages de détail
-│   └── globals.css     # Styles globaux
-├── components/         # Composants réutilisables
-├── data/              # Données JSON
-├── lib/               # Utilitaires
-└── types/             # Types TypeScript
-```
-
-### Scripts disponibles
 ```bash
-npm run dev          # Développement
-npm run build        # Build production
-npm run start        # Serveur production
-npm run lint         # Vérification ESLint
+# Test de la page d'accueil
+curl https://votre-projet.vercel.app/
+
+# Test de l'endpoint hello
+curl "https://votre-projet.vercel.app/api/hello?name=Alice"
+
+# Test de l'endpoint users
+curl https://votre-projet.vercel.app/api/users
+
+# Créer un utilisateur
+curl -X POST https://votre-projet.vercel.app/api/users \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Nouveau", "email": "nouveau@example.com"}'
 ```
 
 ## 🤝 Contribution
 
 1. Fork le projet
-2. Créez une branche feature (`git checkout -b feature/AmazingFeature`)
-3. Commit vos changements (`git commit -m 'Add AmazingFeature'`)
-4. Push vers la branche (`git push origin feature/AmazingFeature`)
+2. Créez une branche pour votre fonctionnalité
+3. Committez vos changements
+4. Poussez vers la branche
 5. Ouvrez une Pull Request
 
 ## 📄 Licence
 
-Ce projet est sous licence MIT. Voir le fichier `LICENSE` pour plus de détails.
+Ce projet est sous licence MIT. Voir le fichier LICENSE pour plus de détails.
 
 ## 🆘 Support
 
-Pour toute question ou problème :
-1. Vérifiez la documentation
-2. Consultez les issues GitHub
-3. Contactez l'équipe de développement
+Si vous rencontrez des problèmes :
+
+1. Vérifiez que toutes les dépendances sont installées
+2. Consultez les logs Vercel pour les erreurs de déploiement
+3. Testez en local avant de déployer
 
 ---
 
-**Développé avec ❤️ pour la communauté CBD**
+**Note :** Ce projet est optimisé pour fonctionner à la fois sur Replit (développement) et Vercel (production).

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+# Package API pour l'application Python

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,67 @@
+from flask import Flask, jsonify, request
+import os
+from datetime import datetime
+
+app = Flask(__name__)
+
+@app.route('/')
+def home():
+    return jsonify({
+        "message": "Bienvenue sur mon API Python!",
+        "timestamp": datetime.now().isoformat(),
+        "status": "success"
+    })
+
+@app.route('/api/hello')
+def hello():
+    name = request.args.get('name', 'Monde')
+    return jsonify({
+        "message": f"Bonjour {name}!",
+        "timestamp": datetime.now().isoformat()
+    })
+
+@app.route('/api/weather')
+def weather():
+    # Simulation d'une API météo
+    return jsonify({
+        "city": "Paris",
+        "temperature": 22,
+        "condition": "Ensoleillé",
+        "timestamp": datetime.now().isoformat()
+    })
+
+@app.route('/api/users', methods=['GET', 'POST'])
+def users():
+    if request.method == 'GET':
+        # Simuler une liste d'utilisateurs
+        users = [
+            {"id": 1, "name": "Alice", "email": "alice@example.com"},
+            {"id": 2, "name": "Bob", "email": "bob@example.com"},
+            {"id": 3, "name": "Charlie", "email": "charlie@example.com"}
+        ]
+        return jsonify({"users": users})
+    
+    elif request.method == 'POST':
+        data = request.get_json()
+        if not data or 'name' not in data:
+            return jsonify({"error": "Le nom est requis"}), 400
+        
+        # Simuler l'ajout d'un utilisateur
+        new_user = {
+            "id": 4,
+            "name": data['name'],
+            "email": data.get('email', f"{data['name'].lower()}@example.com")
+        }
+        return jsonify({"message": "Utilisateur créé", "user": new_user}), 201
+
+@app.errorhandler(404)
+def not_found(error):
+    return jsonify({"error": "Route non trouvée"}), 404
+
+@app.errorhandler(500)
+def internal_error(error):
+    return jsonify({"error": "Erreur interne du serveur"}), 500
+
+# Pour le développement local
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))

--- a/main.py
+++ b/main.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""
+Application Python pour Replit et Vercel
+Ce fichier est utilisé pour le développement local et sur Replit
+"""
+
+from api.index import app
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=8080)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "python-vercel-api"
+version = "1.0.0"
+description = "API Python pour Replit et Vercel"
+authors = [
+    {name = "Votre Nom", email = "votre.email@example.com"}
+]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "flask>=2.3.0",
+    "python-dotenv>=1.0.0",
+    "requests>=2.31.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "black>=23.0.0",
+    "flake8>=6.0.0",
+]
+
+[tool.black]
+line-length = 88
+target-version = ['py38']
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask==2.3.3
+python-dotenv==1.0.0
+requests==2.31.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Package de tests pour l'application Python

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,89 @@
+import pytest
+from api.index import app
+import json
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_home_endpoint(client):
+    """Test de l'endpoint d'accueil"""
+    response = client.get('/')
+    data = json.loads(response.data)
+    
+    assert response.status_code == 200
+    assert 'message' in data
+    assert 'timestamp' in data
+    assert data['status'] == 'success'
+
+def test_hello_endpoint_default(client):
+    """Test de l'endpoint hello avec nom par défaut"""
+    response = client.get('/api/hello')
+    data = json.loads(response.data)
+    
+    assert response.status_code == 200
+    assert 'Bonjour Monde!' in data['message']
+    assert 'timestamp' in data
+
+def test_hello_endpoint_with_name(client):
+    """Test de l'endpoint hello avec nom personnalisé"""
+    response = client.get('/api/hello?name=Alice')
+    data = json.loads(response.data)
+    
+    assert response.status_code == 200
+    assert 'Bonjour Alice!' in data['message']
+
+def test_weather_endpoint(client):
+    """Test de l'endpoint météo"""
+    response = client.get('/api/weather')
+    data = json.loads(response.data)
+    
+    assert response.status_code == 200
+    assert 'city' in data
+    assert 'temperature' in data
+    assert 'condition' in data
+    assert data['city'] == 'Paris'
+
+def test_users_get_endpoint(client):
+    """Test de l'endpoint users GET"""
+    response = client.get('/api/users')
+    data = json.loads(response.data)
+    
+    assert response.status_code == 200
+    assert 'users' in data
+    assert isinstance(data['users'], list)
+    assert len(data['users']) > 0
+
+def test_users_post_endpoint_success(client):
+    """Test de l'endpoint users POST avec succès"""
+    user_data = {'name': 'Test User', 'email': 'test@example.com'}
+    response = client.post('/api/users', 
+                          data=json.dumps(user_data),
+                          content_type='application/json')
+    data = json.loads(response.data)
+    
+    assert response.status_code == 201
+    assert 'message' in data
+    assert 'user' in data
+    assert data['user']['name'] == 'Test User'
+
+def test_users_post_endpoint_missing_name(client):
+    """Test de l'endpoint users POST sans nom"""
+    user_data = {'email': 'test@example.com'}
+    response = client.post('/api/users',
+                          data=json.dumps(user_data),
+                          content_type='application/json')
+    data = json.loads(response.data)
+    
+    assert response.status_code == 400
+    assert 'error' in data
+
+def test_404_error(client):
+    """Test de la gestion des erreurs 404"""
+    response = client.get('/endpoint-inexistant')
+    data = json.loads(response.data)
+    
+    assert response.status_code == 404
+    assert 'error' in data

--- a/vercel.json
+++ b/vercel.json
@@ -1,32 +1,20 @@
 {
-  "buildCommand": "npm run build",
-  "outputDirectory": ".next",
-  "framework": "nextjs",
-  "installCommand": "npm install",
-  "devCommand": "npm run dev",
-  "regions": ["cdg1"],
-  "functions": {
-    "src/app/api/**/*.ts": {
-      "maxDuration": 10
-    }
-  },
-  "headers": [
+  "version": 2,
+  "builds": [
     {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "X-Content-Type-Options",
-          "value": "nosniff"
-        },
-        {
-          "key": "X-Frame-Options",
-          "value": "DENY"
-        },
-        {
-          "key": "X-XSS-Protection",
-          "value": "1; mode=block"
-        }
-      ]
+      "src": "api/index.py",
+      "use": "@vercel/python"
     }
-  ]
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "api/index.py"
+    }
+  ],
+  "functions": {
+    "api/index.py": {
+      "runtime": "python3.9"
+    }
+  }
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable Vercel deployment for the Python Flask application by adapting its structure and adding Vercel configuration.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR refactors the application entry point to `api/index.py` for Vercel's serverless functions and `main.py` for Replit/local development. It also adds Vercel-specific configuration, updates project metadata, and provides comprehensive documentation for seamless deployment.